### PR TITLE
Merkle multiproofs optimization

### DIFF
--- a/crypto-primitives/benches/merkle_tree.rs
+++ b/crypto-primitives/benches/merkle_tree.rs
@@ -191,10 +191,26 @@ mod bytes_mt_benches {
     }
 
     criterion_group! {
-        name = mt_benches;
+        name = mt_create;
+        config = Criterion::default().sample_size(100);
+        targets = merkle_tree_create
+    }
+
+    criterion_group! {
+        name = mt_proof;
+        config = Criterion::default().sample_size(100);
+        targets = merkle_tree_generate_proof, merkle_tree_generate_multi_proof
+    }
+
+    criterion_group! {
+        name = mt_verify;
         config = Criterion::default().sample_size(10);
-        targets = merkle_tree_create, merkle_tree_generate_proof, merkle_tree_verify_proof, merkle_tree_generate_multi_proof, merkle_tree_verify_multi_proof
+        targets = merkle_tree_verify_proof, merkle_tree_verify_multi_proof
     }
 }
 
-criterion_main!(crate::bytes_mt_benches::mt_benches);
+criterion_main!(
+    bytes_mt_benches::mt_create,
+    bytes_mt_benches::mt_proof,
+    bytes_mt_benches::mt_verify
+);

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -760,25 +760,19 @@ fn convert_index_to_last_level(index: usize, tree_height: usize) -> usize {
 /// Example:
 /// If `prev_path` is vec![C,D] and `path` is vec![C,E] (where C,D,E are hashes)
 /// `prefix_encode_path` returns 1,vec![E]
+
 #[inline]
 fn prefix_encode_path<T>(prev_path: &Vec<T>, path: &Vec<T>) -> (usize, Vec<T>)
 where
     T: Eq + Clone,
 {
-    let mut prefix_len = 0;
-    if prev_path.len() != 0 && path.len() != 0 {
-        while prev_path[prefix_len] == path[prefix_len] {
-            prefix_len += 1;
-            if prefix_len == prev_path.len() || prefix_len == path.len() {
-                break;
-            }
-        }
-    }
-    if prefix_len != 0 && prefix_len == prev_path.len() {
-        return (prefix_len, Vec::new());
-    } else {
-        return (prefix_len, path[prefix_len..].to_vec());
-    }
+    let prefix_length = prev_path
+        .iter()
+        .zip(path.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    (prefix_length, path[prefix_length..].to_vec())
 }
 
 fn prefix_decode_path<T>(prev_path: &Vec<T>, prefix_len: usize, suffix: &Vec<T>) -> Vec<T>


### PR DESCRIPTION
Hi @intx4!

I'd like to propose the following changes to your Arkworks PR. The first one concerns the sample size in the benches. I've noticed that it's set to 10 by default. I assume you chose this value due to how slow verification is. However, the sample size for tree creation and (multi-)path proving can be increased by an order of magnitude, and every bench will take roughly the same time to execute. 

The second change is refactoring the function `prefix_encode_path` using chained iterators. This approach is a bit more readable and even slightly more efficient. For reference, I get the following benches for the original implementation on my ThinkPad 14s machine: 
```
Merkle Tree Generate Multi Proof (Leaves as [u8])
                        time:   [470.45 ms 471.29 ms 472.20 ms]
```
When using iterators, the performance seems to improve slightly:
```
Merkle Tree Generate Multi Proof (Leaves as [u8])
                        time:   [462.76 ms 463.66 ms 464.64 ms]
                        change: [-1.8909% -1.6180% -1.3512%] (p = 0.00 < 0.05)
                        Performance has improved.
```